### PR TITLE
Fix calculator registration for Rails 7 and Zeitwerk compatibility

### DIFF
--- a/lib/spree_price_books/engine.rb
+++ b/lib/spree_price_books/engine.rb
@@ -17,8 +17,10 @@ module SpreePriceBooks
 
     config.to_prepare &method(:activate).to_proc
 
-    initializer "spree_active_shipping.register.calculators" do |app|
-      app.config.spree.calculators.shipping_methods << Spree::Calculator::Shipping::FlatMultiCurrencyRate
+    initializer "spree_price_books.register.calculators", after: "spree.register.calculators" do |app|
+      Rails.application.config.after_initialize do
+        app.config.spree.calculators.shipping_methods << Spree::Calculator::Shipping::FlatMultiCurrencyRate
+      end
     end
   end
 end


### PR DESCRIPTION
- Fix initializer name from "spree_active_shipping.register.calculators" to "spree_price_books.register.calculators" (correct gem name)
- Add "after: spree.register.calculators" dependency to ensure proper initialization order
- Wrap calculator registration in after_initialize block to ensure Rails is fully initialized before registering calculators, which is required for Rails 7 and Zeitwerk autoloader compatibility